### PR TITLE
Fix parameters for list_findings

### DIFF
--- a/defectdojo_api/defectdojo_apiv2.py
+++ b/defectdojo_api/defectdojo_apiv2.py
@@ -566,13 +566,13 @@ class DefectDojoAPIv2(object):
             params['date'] = date
 
         if engagement_id_in:
-            params['engagement__id__in'] = engagement_id_in
+            params['test__engagement__in'] = engagement_id_in
 
         if product_id_in:
-            params['product__id__in'] = product_id_in
+            params['test__engagement__product__in'] = product_id_in
 
         if test_id_in:
-            params['test__id__in'] = test_id_in
+            params['test__in'] = test_id_in
 
         if build:
             params['build_id__contains'] = build

--- a/defectdojo_api/defectdojo_apiv2.py
+++ b/defectdojo_api/defectdojo_apiv2.py
@@ -566,13 +566,13 @@ class DefectDojoAPIv2(object):
             params['date'] = date
 
         if engagement_id_in:
-            params['test__engagement__in'] = engagement_id_in
+            params['test__engagement'] = engagement_id_in
 
         if product_id_in:
-            params['test__engagement__product__in'] = product_id_in
+            params['test__engagement__product'] = product_id_in
 
         if test_id_in:
-            params['test__in'] = test_id_in
+            params['test'] = test_id_in
 
         if build:
             params['build_id__contains'] = build


### PR DESCRIPTION
Not sure how the `__in` and the `__lt` were intended to be used, but they simply translate to arguments to the REST API, and of course, they do not exist there.

Or am I missing something @valentijnscholten ?